### PR TITLE
Feat: Function values. Add macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llvm-lib"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Evgeny Ukhanov <evgeny@ukhanov.org.ua>"]
 description = "LLVM library with safe and flexibility in mind, without over complexity based on LLVM-C API"
 categories = ["compilers", "development-tools", "development-tools::build-utils"]

--- a/src/core/context.rs
+++ b/src/core/context.rs
@@ -402,7 +402,7 @@ impl MetadataKindId {
             core::LLVMGetMDKindIDInContext(
                 context.get_ref(),
                 c_name.as_ptr(),
-                *CUint::from(c_name.to_bytes().len()),
+                *CUint::from(c_name.count_bytes()),
             )
         };
         Self(id)
@@ -429,9 +429,8 @@ impl MetadataKindId {
     #[must_use]
     pub fn get_md_kind_id(name: &str) -> Self {
         let c_name = CString::from(name);
-        let id = unsafe {
-            core::LLVMGetMDKindID(c_name.as_ptr(), *CUint::from(c_name.to_bytes().len()))
-        };
+        let id =
+            unsafe { core::LLVMGetMDKindID(c_name.as_ptr(), *CUint::from(c_name.count_bytes())) };
         Self(id)
     }
 }
@@ -484,7 +483,7 @@ impl AttributeRef {
     pub fn get_enum_attribute_kind_for_name(name: &str) -> u32 {
         let c_name = CString::from(name);
         unsafe {
-            core::LLVMGetEnumAttributeKindForName(c_name.as_ptr(), *SizeT(c_name.to_bytes().len()))
+            core::LLVMGetEnumAttributeKindForName(c_name.as_ptr(), *SizeT(c_name.count_bytes()))
         }
     }
 
@@ -643,9 +642,9 @@ impl AttributeRef {
             core::LLVMCreateStringAttribute(
                 context.get_ref(),
                 c_key.as_ptr(),
-                *CUint::from(c_key.to_bytes().len()),
+                *CUint::from(c_key.count_bytes()),
                 c_value.as_ptr(),
-                *CUint::from(c_value.to_bytes().len()),
+                *CUint::from(c_value.count_bytes()),
             )
         };
         Self(attr)

--- a/src/core/module.rs
+++ b/src/core/module.rs
@@ -307,7 +307,7 @@ impl ModuleRef {
             core::LLVMSetModuleIdentifier(
                 self.0,
                 c_ident.as_ptr(),
-                *SizeT::from(c_ident.to_bytes().len()),
+                *SizeT::from(c_ident.count_bytes()),
             );
         }
     }
@@ -332,7 +332,7 @@ impl ModuleRef {
             core::LLVMSetSourceFileName(
                 self.0,
                 c_name.as_ptr(),
-                *SizeT::from(c_name.to_bytes().len()),
+                *SizeT::from(c_name.count_bytes()),
             );
         }
     }
@@ -396,9 +396,8 @@ impl ModuleRef {
     #[must_use]
     pub fn get_module_flag(&self, key: &str) -> MetadataRef {
         let c_key = CString::from(key);
-        let metadata = unsafe {
-            core::LLVMGetModuleFlag(self.0, c_key.as_ptr(), *SizeT(c_key.to_bytes().len()))
-        };
+        let metadata =
+            unsafe { core::LLVMGetModuleFlag(self.0, c_key.as_ptr(), *SizeT(c_key.count_bytes())) };
         MetadataRef(metadata)
     }
 
@@ -409,7 +408,7 @@ impl ModuleRef {
                 self.0,
                 (*behavior).into(),
                 c_key.as_ptr(),
-                c_key.to_bytes().len(),
+                c_key.count_bytes(),
                 val.0,
             );
         }
@@ -474,7 +473,7 @@ impl ModuleRef {
     pub fn set_module_inline_asm(&self, asm: &str) {
         let c_asm = CString::from(asm);
         unsafe {
-            core::LLVMSetModuleInlineAsm2(self.0, c_asm.as_ptr(), *SizeT(c_asm.to_bytes().len()));
+            core::LLVMSetModuleInlineAsm2(self.0, c_asm.as_ptr(), *SizeT(c_asm.count_bytes()));
         }
     }
 
@@ -482,7 +481,7 @@ impl ModuleRef {
     pub fn append_module_inline_asm(&self, asm: &str) {
         let c_asm = CString::from(asm);
         unsafe {
-            core::LLVMAppendModuleInlineAsm(self.0, c_asm.as_ptr(), *SizeT(c_asm.to_bytes().len()));
+            core::LLVMAppendModuleInlineAsm(self.0, c_asm.as_ptr(), *SizeT(c_asm.count_bytes()));
         }
     }
 
@@ -627,9 +626,9 @@ pub fn get_inline_asm(
         core::LLVMGetInlineAsm(
             ty.get_ref(),
             c_asm_string.as_ptr(),
-            *SizeT(c_asm_string.to_bytes().len()),
+            *SizeT(c_asm_string.count_bytes()),
             c_constraints.as_ptr(),
-            *SizeT(c_constraints.to_bytes().len()),
+            *SizeT(c_constraints.count_bytes()),
             *CInt::from(has_side_effects),
             *CInt::from(is_align_stack),
             dialect.into(),

--- a/src/core/types/function.rs
+++ b/src/core/types/function.rs
@@ -54,12 +54,7 @@ impl FunctionTypeRef {
     /// Returns an instance of `Self` representing the function type with the specified return type, parameters, and varargs setting.
     #[must_use]
     pub fn function_type(return_type: &TypeRef, param_types: &[TypeRef], is_var_arg: bool) -> Self {
-        let mut param_types = param_types.iter().map(|v| v.0).collect::<Vec<_>>();
-        let parameters = if param_types.is_empty() {
-            std::ptr::null_mut()
-        } else {
-            param_types.as_mut_ptr()
-        };
+        let parameters = crate::to_mut_ptr!(param_types);
         unsafe {
             Self(core::LLVMFunctionType(
                 return_type.0,

--- a/src/core/types/other.rs
+++ b/src/core/types/other.rs
@@ -422,21 +422,8 @@ impl TargetExtTypeRef {
         type_params: &[TypeRef],
         int_params: &[u32],
     ) -> Self {
-        let type_params_ptr = if type_params.is_empty() {
-            std::ptr::null_mut()
-        } else {
-            let mut type_params = type_params.iter().map(|v| v.0).collect::<Vec<_>>();
-            type_params.as_mut_ptr()
-        };
-        let int_params_ptr = if int_params.is_empty() {
-            std::ptr::null_mut()
-        } else {
-            let mut int_params = int_params
-                .iter()
-                .map(|v| *CUint::from(*v))
-                .collect::<Vec<_>>();
-            int_params.as_mut_ptr()
-        };
+        let type_params_ptr = crate::to_mut_ptr!(type_params);
+        let int_params_ptr = crate::map_mut_ptr!(int_params, |v| *CUint::from(*v));
 
         let c_name = CString::from(name);
         unsafe {

--- a/src/core/types/structs.rs
+++ b/src/core/types/structs.rs
@@ -59,16 +59,11 @@ impl StructTypeRef {
         element_types: &[TypeRef],
         packed: bool,
     ) -> Self {
-        let mut element_types = element_types.iter().map(|v| v.0).collect::<Vec<_>>();
-        let elements = if element_types.is_empty() {
-            std::ptr::null_mut()
-        } else {
-            element_types.as_mut_ptr()
-        };
+        let elements_ptr = crate::to_mut_ptr!(element_types);
         unsafe {
             Self(core::LLVMStructTypeInContext(
                 context.get_ref(),
-                elements,
+                elements_ptr,
                 *CUint::from(element_types.len()),
                 *CInt::from(packed),
             ))
@@ -96,15 +91,10 @@ impl StructTypeRef {
     /// Returns an instance of `Self` representing the structure type in the global context.
     #[must_use]
     pub fn struct_type(element_types: &[TypeRef], packed: bool) -> Self {
-        let mut element_types = element_types.iter().map(|v| v.0).collect::<Vec<_>>();
-        let elements = if element_types.is_empty() {
-            std::ptr::null_mut()
-        } else {
-            element_types.as_mut_ptr()
-        };
+        let elements_ptr = crate::to_mut_ptr!(element_types);
         unsafe {
             Self(core::LLVMStructType(
-                elements,
+                elements_ptr,
                 *CUint::from(element_types.len()),
                 *CInt::from(packed),
             ))
@@ -185,16 +175,11 @@ impl StructTypeRef {
     /// - `element_types`: A slice of `Self` representing the types of the elements (fields) in the structure. Each element in this slice corresponds to a field in the structure.
     /// - `packed`: A boolean indicating whether the structure should be packed (`true`) or unpacked (`false`). A packed structure has its fields tightly packed without padding.
     pub fn struct_set_body(&self, element_types: &[Self], packed: bool) {
-        let mut element_types = element_types.iter().map(|v| v.0).collect::<Vec<_>>();
-        let elements = if element_types.is_empty() {
-            std::ptr::null_mut()
-        } else {
-            element_types.as_mut_ptr()
-        };
+        let elements_ptr = crate::to_mut_ptr!(element_types);
         unsafe {
             core::LLVMStructSetBody(
                 self.0,
-                elements,
+                elements_ptr,
                 *CUint::from(element_types.len()),
                 *CInt::from(packed),
             );

--- a/src/core/values/constants/composite.rs
+++ b/src/core/values/constants/composite.rs
@@ -148,12 +148,7 @@ pub fn const_struct_in_context(
     constant_vals: &[ValueRef],
     packed: bool,
 ) -> ValueRef {
-    let mut constant_vals = constant_vals.iter().map(|v| v.0).collect::<Vec<_>>();
-    let constant_vals_ptr = if constant_vals.is_empty() {
-        std::ptr::null_mut()
-    } else {
-        constant_vals.as_mut_ptr()
-    };
+    let constant_vals_ptr = crate::to_mut_ptr!(constant_vals);
     unsafe {
         ValueRef(core::LLVMConstStructInContext(
             context.get_ref(),
@@ -188,12 +183,7 @@ pub fn const_struct_in_context(
 /// Returns an instance of `ValueRef`, which encapsulates the constant struct value created in the global context.
 #[must_use]
 pub fn const_struct(constant_vals: &[ValueRef], packed: bool) -> ValueRef {
-    let mut constant_vals = constant_vals.iter().map(|v| v.0).collect::<Vec<_>>();
-    let constant_vals_ptr = if constant_vals.is_empty() {
-        std::ptr::null_mut()
-    } else {
-        constant_vals.as_mut_ptr()
-    };
+    let constant_vals_ptr = crate::to_mut_ptr!(constant_vals);
     unsafe {
         ValueRef(core::LLVMConstStruct(
             constant_vals_ptr,
@@ -223,12 +213,7 @@ pub fn const_struct(constant_vals: &[ValueRef], packed: bool) -> ValueRef {
 /// Returns an instance of [`ValueRef`], which encapsulates the constant array value created with the specified element type and elements.
 #[must_use]
 pub fn const_array2(element_type: &TypeRef, constant_vals: &[ValueRef]) -> ValueRef {
-    let mut constant_vals = constant_vals.iter().map(|v| v.0).collect::<Vec<_>>();
-    let constant_vals_ptr = if constant_vals.is_empty() {
-        std::ptr::null_mut()
-    } else {
-        constant_vals.as_mut_ptr()
-    };
+    let constant_vals_ptr = crate::to_mut_ptr!(constant_vals);
     unsafe {
         ValueRef(core::LLVMConstArray2(
             element_type.get_ref(),
@@ -258,12 +243,7 @@ pub fn const_array2(element_type: &TypeRef, constant_vals: &[ValueRef]) -> Value
 /// Returns an instance of [`ValueRef`], which encapsulates the constant named struct value created with the specified fields.
 #[must_use]
 pub fn const_named_struct(struct_type: &TypeRef, constant_vals: &[ValueRef]) -> ValueRef {
-    let mut constant_vals = constant_vals.iter().map(|v| v.0).collect::<Vec<_>>();
-    let constant_vals_ptr = if constant_vals.is_empty() {
-        std::ptr::null_mut()
-    } else {
-        constant_vals.as_mut_ptr()
-    };
+    let constant_vals_ptr = crate::to_mut_ptr!(constant_vals);
     unsafe {
         ValueRef(core::LLVMConstNamedStruct(
             struct_type.get_ref(),
@@ -324,12 +304,7 @@ pub fn get_aggregate_element(val: &ValueRef, idx: u32) -> Option<ValueRef> {
 /// Returns an instance of [`ValueRef`], which encapsulates the constant vector value created from the specified scalar constants.
 #[must_use]
 pub fn const_vector(scalar_constant_vals: &[ValueRef]) -> ValueRef {
-    let mut scalar_constant_vals = scalar_constant_vals.iter().map(|v| v.0).collect::<Vec<_>>();
-    let scalar_constant_vals_ptr = if scalar_constant_vals.is_empty() {
-        std::ptr::null_mut()
-    } else {
-        scalar_constant_vals.as_mut_ptr()
-    };
+    let scalar_constant_vals_ptr = crate::to_mut_ptr!(scalar_constant_vals);
     unsafe {
         ValueRef(core::LLVMConstVector(
             scalar_constant_vals_ptr,

--- a/src/core/values/constants/expressions.rs
+++ b/src/core/values/constants/expressions.rs
@@ -422,12 +422,7 @@ pub fn const_gep2(
     constant_val: &ValueRef,
     constant_indices: &[ValueRef],
 ) -> ValueRef {
-    let mut constant_indices = constant_indices.iter().map(|v| v.0).collect::<Vec<_>>();
-    let constant_indices_ptr = if constant_indices.is_empty() {
-        std::ptr::null_mut()
-    } else {
-        constant_indices.as_mut_ptr()
-    };
+    let constant_indices_ptr = crate::to_mut_ptr!(constant_indices);
     unsafe {
         ValueRef(core::LLVMConstGEP2(
             ty.get_ref(),
@@ -466,12 +461,7 @@ pub fn const_in_bounds_gep2(
     constant_val: &ValueRef,
     constant_indices: &[ValueRef],
 ) -> ValueRef {
-    let mut constant_indices = constant_indices.iter().map(|v| v.0).collect::<Vec<_>>();
-    let constant_indices_ptr = if constant_indices.is_empty() {
-        std::ptr::null_mut()
-    } else {
-        constant_indices.as_mut_ptr()
-    };
+    let constant_indices_ptr = crate::to_mut_ptr!(constant_indices);
     unsafe {
         ValueRef(core::LLVMConstInBoundsGEP2(
             ty.get_ref(),

--- a/src/core/values/constants/global_values.rs
+++ b/src/core/values/constants/global_values.rs
@@ -464,15 +464,7 @@ pub fn value_metadata_entries_get_kind(
     value_metadata_entries: &[ValueMetadataEntry],
     index: u32,
 ) -> u32 {
-    let mut entries = value_metadata_entries
-        .iter()
-        .map(|v| v.0)
-        .collect::<Vec<_>>();
-    let entries_ptr = if entries.is_empty() {
-        std::ptr::null_mut()
-    } else {
-        entries.as_mut_ptr()
-    };
+    let entries_ptr = crate::to_mut_ptr!(value_metadata_entries);
     unsafe { core::LLVMValueMetadataEntriesGetKind(entries_ptr, *CUint::from(index)) }
 }
 
@@ -504,15 +496,7 @@ pub fn value_metadata_entries_get_metadata(
     value_metadata_entries: &[ValueMetadataEntry],
     index: u32,
 ) -> MetadataRef {
-    let mut entries = value_metadata_entries
-        .iter()
-        .map(|v| v.0)
-        .collect::<Vec<_>>();
-    let entries_ptr = if entries.is_empty() {
-        std::ptr::null_mut()
-    } else {
-        entries.as_mut_ptr()
-    };
+    let entries_ptr = crate::to_mut_ptr!(value_metadata_entries);
     unsafe {
         MetadataRef::from(core::LLVMValueMetadataEntriesGetMetadata(
             entries_ptr,

--- a/src/core/values/function_values/function_parameters.rs
+++ b/src/core/values/function_values/function_parameters.rs
@@ -1,0 +1,234 @@
+use super::ValueRef;
+use llvm_sys::core;
+
+/// Obtains the number of parameters in a function.
+///
+/// This function wraps the `LLVMCountParams` function from the LLVM core library. It returns the count of parameters
+/// that the specified function accepts.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+///
+/// # Returns
+///
+/// Returns an `unsigned` integer (`u32`) indicating the number of parameters in the function.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+#[must_use]
+pub fn count_params(fn_val: &ValueRef) -> u32 {
+    unsafe { core::LLVMCountParams(fn_val.0) }
+}
+
+/// Retrieves the parameters of a function.
+///
+/// This function wraps the `LLVMGetParams` function from the LLVM core library. It fills the provided mutable slice
+/// with the parameters of the specified function. Each parameter is represented as a `ValueRef`.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `params`: A mutable slice of `ValueRef` where the function's parameters will be stored.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The `params` slice must be pre-allocated and have a length of at least `count_params(fn_val)`.
+pub fn get_params(fn_val: &ValueRef, params: &mut &[ValueRef]) {
+    let params_ptr = crate::to_mut_ptr!(params);
+    unsafe {
+        core::LLVMGetParams(fn_val.0, params_ptr);
+    }
+}
+
+/// Retrieves a specific parameter of a function by index.
+///
+/// This function wraps the `LLVMGetParam` function from the LLVM core library. It returns the parameter at the
+/// specified index within the function's parameter list.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `index`: The zero-based index of the parameter to retrieve.
+///
+/// # Returns
+///
+/// Returns an `Option<ValueRef>` containing the parameter if the index is valid, or `None` if the index is out of bounds.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - `index` must be less than the number of parameters in the function.
+#[must_use]
+pub fn get_param(fn_val: &ValueRef, index: u32) -> Option<ValueRef> {
+    unsafe {
+        let param = core::LLVMGetParam(fn_val.0, index);
+        if param.is_null() {
+            None
+        } else {
+            Some(ValueRef(param))
+        }
+    }
+}
+
+/// Retrieves the parent function of a given argument.
+///
+/// This function wraps the `LLVMGetParamParent` function from the LLVM core library. It returns the function to
+/// which the specified argument belongs.
+///
+/// # Parameters
+///
+/// - `arg`: The `ValueRef` representing the argument.
+///
+/// # Returns
+///
+/// Returns an `Option<ValueRef>` containing the parent function if it exists, or `None` otherwise.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid argument within a function.
+#[must_use]
+pub fn get_param_parent(arg: &ValueRef) -> Option<ValueRef> {
+    unsafe {
+        let parent = core::LLVMGetParamParent(arg.0);
+        if parent.is_null() {
+            None
+        } else {
+            Some(ValueRef(parent))
+        }
+    }
+}
+
+/// Retrieves the first parameter of a function.
+///
+/// This function wraps the `LLVMGetFirstParam` function from the LLVM core library. It returns the first parameter
+/// of the specified function.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+///
+/// # Returns
+///
+/// Returns an `Option<ValueRef>` containing the first parameter if it exists, or `None` if the function has no parameters.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+#[must_use]
+pub fn get_first_param(fn_val: &ValueRef) -> Option<ValueRef> {
+    unsafe {
+        let first = core::LLVMGetFirstParam(fn_val.0);
+        if first.is_null() {
+            None
+        } else {
+            Some(ValueRef(first))
+        }
+    }
+}
+
+/// Retrieves the last parameter of a function.
+///
+/// This function wraps the `LLVMGetLastParam` function from the LLVM core library. It returns the last parameter
+/// of the specified function.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+///
+/// # Returns
+///
+/// Returns an `Option<ValueRef>` containing the last parameter if it exists, or `None` if the function has no parameters.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+#[must_use]
+pub fn get_last_param(fn_val: &ValueRef) -> Option<ValueRef> {
+    unsafe {
+        let last = core::LLVMGetLastParam(fn_val.0);
+        if last.is_null() {
+            None
+        } else {
+            Some(ValueRef(last))
+        }
+    }
+}
+
+/// Retrieves the next parameter in a function's parameter list.
+///
+/// This function wraps the `LLVMGetNextParam` function from the LLVM core library. Given a current parameter, it returns
+/// the next parameter in the function's parameter list.
+///
+/// # Parameters
+///
+/// - `arg`: The `ValueRef` representing the current parameter.
+///
+/// # Returns
+///
+/// Returns an `Option<ValueRef>` containing the next parameter if it exists, or `None` if there is no next parameter.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid parameter within a function.
+#[must_use]
+pub fn get_next_param(arg: &ValueRef) -> Option<ValueRef> {
+    unsafe {
+        let next = core::LLVMGetNextParam(arg.0);
+        if next.is_null() {
+            None
+        } else {
+            Some(ValueRef(next))
+        }
+    }
+}
+
+/// Retrieves the previous parameter in a function's parameter list.
+///
+/// This function wraps the `LLVMGetPreviousParam` function from the LLVM core library. Given a current parameter, it returns
+/// the previous parameter in the function's parameter list.
+///
+/// # Parameters
+///
+/// - `arg`: The `ValueRef` representing the current parameter.
+///
+/// # Returns
+///
+/// Returns an `Option<ValueRef>` containing the previous parameter if it exists, or `None` if there is no previous parameter.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid parameter within a function.
+#[must_use]
+pub fn get_previous_param(arg: &ValueRef) -> Option<ValueRef> {
+    unsafe {
+        let previous = core::LLVMGetPreviousParam(arg.0);
+        if previous.is_null() {
+            None
+        } else {
+            Some(ValueRef(previous))
+        }
+    }
+}
+
+/// Sets the alignment for a function parameter.
+///
+/// This function wraps the `LLVMSetParamAlignment` function from the LLVM core library. It sets the alignment requirement
+/// for the specified function parameter.
+///
+/// # Parameters
+///
+/// - `arg`: The `ValueRef` representing the parameter.
+/// - `align`: The alignment (`unsigned`, typically `u32`) to set for the parameter.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid parameter within a function.
+/// - `align` must be a valid alignment value as per LLVM's requirements.
+pub fn set_param_alignment(arg: &ValueRef, align: u32) {
+    unsafe {
+        core::LLVMSetParamAlignment(arg.0, align);
+    }
+}

--- a/src/core/values/function_values/mod.rs
+++ b/src/core/values/function_values/mod.rs
@@ -1,0 +1,718 @@
+use super::ValueRef;
+use crate::core::context::{AttributeRef, ContextRef};
+use crate::core::module::ModuleRef;
+use crate::core::types::TypeRef;
+use crate::{CStr, CString, CUint, GetRef, SizeT};
+use llvm_sys::core;
+
+pub mod function_parameters;
+
+/// Removes a function from its containing module and deallocates it.
+///
+/// This function wraps the `LLVMDeleteFunction` function from the LLVM core library. It removes the function
+/// represented by `val` from its parent module and deallocates all associated resources. After calling this
+/// function, the `ValueRef` should no longer be used, as it references deallocated memory.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - After deletion, the `ValueRef` becomes invalid and should not be used.
+pub fn delete_function(val: &ValueRef) {
+    unsafe {
+        core::LLVMDeleteFunction(val.0);
+    }
+}
+
+/// Checks whether the given function has an associated personality function.
+///
+/// This function wraps the `LLVMHasPersonalityFn` function from the LLVM core library. A personality function
+/// is used in exception handling to provide language-specific semantics for stack unwinding.
+///
+/// # Parameters
+///
+/// - `val`: The `ValueRef` representing the function to check.
+///
+/// # Returns
+///
+/// Returns `true` if the function has an associated personality function, or `false` otherwise.
+#[must_use]
+pub fn has_personality_fn(val: &ValueRef) -> bool {
+    unsafe { core::LLVMHasPersonalityFn(val.0) != 0 }
+}
+
+/// Retrieves the personality function attached to the function.
+///
+/// This function wraps the `LLVMGetPersonalityFn` function from the LLVM core library. The personality
+/// function is used in exception handling to provide language-specific semantics for stack unwinding.
+///
+/// # Parameters
+///
+/// - `val`: The `ValueRef` representing the function.
+///
+/// # Returns
+///
+/// Returns an `Option<ValueRef>` representing the personality function if one is attached to the function,
+/// or `None` if no personality function is present.
+#[must_use]
+pub fn get_personality_fn(val: &ValueRef) -> Option<ValueRef> {
+    unsafe {
+        let personality_fn = core::LLVMGetPersonalityFn(val.0);
+        if personality_fn.is_null() {
+            None
+        } else {
+            Some(ValueRef(personality_fn))
+        }
+    }
+}
+
+/// Sets the personality function attached to the function.
+///
+/// This function wraps the `LLVMSetPersonalityFn` function from the LLVM core library. The personality
+/// function is used in exception handling to provide language-specific semantics for stack unwinding. By
+/// setting a personality function, you define how exceptions are handled within the function.
+///
+/// # Parameters
+///
+/// - `val`: The `ValueRef` representing the function.
+/// - `personality_fn`: A reference to the `ValueRef` representing the personality function to attach.
+pub fn set_personality_fn(val: &ValueRef, personality_fn: &ValueRef) {
+    unsafe {
+        core::LLVMSetPersonalityFn(val.0, personality_fn.0);
+    }
+}
+
+/// Looks up the intrinsic ID number that matches the given function name within the module.
+///
+/// This function wraps the `LLVMLookupIntrinsicID` function from the LLVM core library. It searches for an intrinsic
+/// function within the LLVM module represented by `m` that matches the specified name. Intrinsic functions are
+/// special functions provided by LLVM that perform specific operations at a lower level.
+///
+/// # Parameters
+///
+/// - `m`: The `ModuleRef` representing the LLVM module.
+/// - `name`: The name (`&str`) of the intrinsic function to look up.
+///
+/// # Returns
+///
+/// Returns an `Option<u32>` containing the intrinsic ID if a matching intrinsic is found, or `None` if no
+/// matching intrinsic exists within the module.
+#[must_use]
+pub fn lookup_intrinsic_id(name: &str) -> Option<u32> {
+    let c_string = CString::from(name);
+    unsafe {
+        let id =
+            core::LLVMLookupIntrinsicID(c_string.as_ptr(), *SizeT::from(c_string.count_bytes()));
+        if id == 0 {
+            None
+        } else {
+            Some(id)
+        }
+    }
+}
+
+/// Retrieves the intrinsic ID number from a function instance.
+///
+/// This function wraps the `LLVMGetIntrinsicID` function from the LLVM core library. Intrinsic functions in
+/// LLVM have unique ID numbers that can be used to identify and categorize them.
+///
+/// # Parameters
+///
+/// - `val`: The `ValueRef` representing the function.
+///
+/// # Returns
+///
+/// Returns a `u32` representing the intrinsic ID of the function. If the function is not an intrinsic, the ID
+/// returned will be `0`.
+#[must_use]
+pub fn get_intrinsic_id(val: &ValueRef) -> u32 {
+    unsafe { core::LLVMGetIntrinsicID(val.0) }
+}
+
+/// Creates or inserts the declaration of an intrinsic function within the module.
+///
+/// This function wraps the `LLVMGetIntrinsicDeclaration` function from the LLVM core library. It either retrieves
+/// an existing declaration of the specified intrinsic or creates a new one if it does not already exist. For
+/// overloaded intrinsics, parameter types must be provided to uniquely identify the desired overload.
+///
+/// # Parameters
+///
+/// - `m`: The `ModuleRef` representing the LLVM module.
+/// - `id`: The intrinsic ID (`u32`) corresponding to the desired intrinsic function.
+/// - `param_types`: A slice of LLVM type references (`&[LLVMTypeRef]`) representing the parameter types of the intrinsic.
+///                  This is necessary for overloaded intrinsics to uniquely identify the correct version.
+///
+/// # Returns
+///
+/// Returns a `ValueRef` representing the intrinsic function declaration within the module. If the declaration
+/// cannot be created or retrieved, the returned `ValueRef` may be null, so users should ensure that the
+/// declaration was successfully obtained.
+#[must_use]
+pub fn get_intrinsic_declaration(m: &ModuleRef, id: u32, param_types: &[TypeRef]) -> ValueRef {
+    let param_types_ptr = crate::to_mut_ptr!(param_types);
+    unsafe {
+        let intrinsic = core::LLVMGetIntrinsicDeclaration(
+            m.get_ref(),
+            *CUint::from(id),
+            param_types_ptr,
+            *SizeT::from(param_types.len()),
+        );
+        ValueRef(intrinsic)
+    }
+}
+
+/// Retrieves the type of intrinsic. For overloaded intrinsics, parameter
+/// types must be provided to uniquely identify an overload.
+///
+/// This function wraps the `LLVMIntrinsicGetType` function from the LLVM core library. It obtains the
+/// LLVM type (`LLVMTypeRef`) of the intrinsic identified by `id` within the given context. For overloaded
+/// intrinsics, providing the correct parameter types ensures that the correct type is retrieved.
+///
+/// # Parameters
+///
+/// - `ctx`: The `LLVMContextRef` representing the LLVM context.
+/// - `id`: The intrinsic ID (`u32`) corresponding to the desired intrinsic function.
+/// - `param_types`: A slice of LLVM type references (`&[LLVMTypeRef]`) representing the parameter types of the intrinsic.
+///                  This is necessary for overloaded intrinsics to uniquely identify the correct version.
+///
+/// # Returns
+///
+/// Returns an `LLVMTypeRef` representing the type of the intrinsic. If the intrinsic does not exist or the
+/// parameter types do not match any overload, the returned type may be null.
+#[must_use]
+pub fn intrinsic_get_type(ctx: &ContextRef, id: u32, param_types: &[TypeRef]) -> TypeRef {
+    let param_types_ptr = crate::to_mut_ptr!(param_types);
+    unsafe {
+        let type_ref = core::LLVMIntrinsicGetType(
+            ctx.get_ref(),
+            *CUint::from(id),
+            param_types_ptr,
+            *SizeT::from(param_types.len()),
+        );
+        TypeRef::from(type_ref)
+    }
+}
+
+/// Retrieves the name of an intrinsic.
+///
+/// This function wraps the `LLVMIntrinsicGetName` function from the LLVM core library. It obtains the name of
+/// the intrinsic identified by `id`.
+///
+/// # Parameters
+///
+/// - `id`: The intrinsic ID (`u32`) corresponding to the desired intrinsic function.
+/// - `name_length`: A mutable reference to a `usize` where the length of the name will be stored.
+///
+/// # Returns
+///
+/// Returns a raw pointer to a null-terminated string (`*const i8`) representing the name of the intrinsic.
+/// The length of the name is stored in `name_length`. The returned string should not be modified or freed by
+/// the caller.
+pub fn intrinsic_get_name(id: u32, name_length: &mut usize) -> *const i8 {
+    unsafe { core::LLVMIntrinsicGetName(id, name_length) }
+}
+
+/// Copies the name of an overloaded intrinsic identified by a given list of
+/// parameter types.
+///
+/// Unlike `intrinsic_get_name`, the caller is responsible for freeing the
+/// returned string.
+///
+/// This function wraps the `LLVMIntrinsicCopyOverloadedName2` function from the LLVM core library. It retrieves
+/// the name of an overloaded intrinsic based on the provided parameter types.
+///
+/// # Parameters
+///
+/// - `m`: The `ModuleRef` representing the LLVM module.
+/// - `id`: The intrinsic ID (`u32`) corresponding to the desired intrinsic function.
+/// - `param_types`: A slice of LLVM type references (`&[LLVMTypeRef]`) representing the parameter types of the intrinsic.
+/// - `name_length`: A mutable reference to a `usize` where the length of the name will be stored.
+///
+/// # Returns
+///
+/// Returns a raw pointer to a null-terminated string (`*const i8`) representing the name of the overloaded intrinsic.
+/// The length of the name is stored in `name_length`. The caller is responsible for freeing the returned string
+/// using the appropriate memory deallocation function (e.g., `LLVMDisposeMessage`).
+#[must_use]
+pub fn intrinsic_copy_overloaded_name2(
+    m: &ModuleRef,
+    id: u32,
+    param_types: &[TypeRef],
+) -> Option<String> {
+    let param_types_ptr = crate::to_mut_ptr!(param_types);
+    unsafe {
+        let mut length = *SizeT::from(0_usize);
+
+        let c_str = core::LLVMIntrinsicCopyOverloadedName2(
+            m.get_ref(),
+            id,
+            param_types_ptr,
+            *SizeT::from(param_types.len()),
+            &mut length,
+        );
+        if c_str.is_null() {
+            return None;
+        }
+        Some(CStr::new(c_str).to_string())
+    }
+}
+
+/// Determines if the intrinsic identified by the given ID is overloaded.
+///
+/// This function wraps the `LLVMIntrinsicIsOverloaded` function from the LLVM core library. Overloaded intrinsics
+/// can have multiple versions differentiated by their parameter types.
+///
+/// # Parameters
+///
+/// - `id`: The intrinsic ID (`u32`) corresponding to the desired intrinsic function.
+///
+/// # Returns
+///
+/// Returns `true` if the intrinsic is overloaded, or `false` otherwise.
+#[must_use]
+pub fn intrinsic_is_overloaded(id: u32) -> bool {
+    unsafe { core::LLVMIntrinsicIsOverloaded(*CUint::from(id)) != 0 }
+}
+
+/// Obtains the calling convention of a function.
+///
+/// The returned value corresponds to the LLVM calling convention enumeration.
+///
+/// This function wraps the `LLVMGetFunctionCallConv` function from the LLVM core library.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+///
+/// # Returns
+///
+/// Returns an `unsigned` integer corresponding to the LLVM calling convention of the function.
+#[must_use]
+pub fn get_function_call_conv(fn_val: &ValueRef) -> u32 {
+    unsafe { core::LLVMGetFunctionCallConv(fn_val.0) }
+}
+
+/// Sets the calling convention of a function.
+///
+/// This function wraps the `LLVMSetFunctionCallConv` function from the LLVM core library.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `cc`: The LLVM calling convention (`u32`) to set for the function.
+pub fn set_function_call_conv(fn_val: &ValueRef, cc: u32) {
+    unsafe {
+        core::LLVMSetFunctionCallConv(fn_val.0, cc);
+    }
+}
+
+/// Obtains the name of the garbage collector to use during code generation.
+///
+/// This function wraps the `LLVMGetGC` function from the LLVM core library. The garbage collector name
+/// specifies which garbage collection strategy to use for the function.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+///
+/// # Returns
+///
+/// Returns a raw pointer to a null-terminated string (`*const i8`) representing the name of the garbage collector.
+/// If no garbage collector is specified, it may return a null pointer.
+///
+/// # Safety
+///
+/// The returned string should not be modified or freed by the caller.
+#[must_use]
+pub fn get_gc(fn_val: &ValueRef) -> Option<String> {
+    unsafe {
+        let c_str = core::LLVMGetGC(fn_val.0);
+        if c_str.is_null() {
+            return None;
+        }
+        Some(CStr::new(c_str).to_string())
+    }
+}
+
+/// Defines the garbage collector to use during code generation.
+///
+/// This function wraps the `LLVMSetGC` function from the LLVM core library. It sets the name of the garbage collector
+/// to be used for the specified function during code generation.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `name`: The name (`&str`) of the garbage collector to set.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The `name` must not contain null bytes.
+///
+/// # Example
+///
+/// ```rust
+/// set_gc(function, "my_gc");
+/// ```
+pub fn set_gc(fn_val: &ValueRef, name: &str) {
+    let c_string = CString::from(name);
+    unsafe {
+        core::LLVMSetGC(fn_val.0, c_string.as_ptr());
+    }
+}
+
+/// Retrieves the prefix data associated with a function.
+///
+/// This function wraps the `LLVMGetPrefixData` function from the LLVM core library. It obtains the prefix data
+/// attached to the specified function. Prefix data is used to attach additional information to functions.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+///
+/// # Returns
+///
+/// Returns an `Option<ValueRef>` containing the prefix data if it exists, or `None` otherwise.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The returned `ValueRef` should not be used if it is `None`.
+#[must_use]
+pub fn get_prefix_data(fn_val: &ValueRef) -> Option<ValueRef> {
+    unsafe {
+        let prefix_data = core::LLVMGetPrefixData(fn_val.0);
+        if prefix_data.is_null() {
+            None
+        } else {
+            Some(ValueRef(prefix_data))
+        }
+    }
+}
+
+/// Checks if a given function has prefix data.
+///
+/// This function wraps the `LLVMHasPrefixData` function from the LLVM core library. It determines whether
+/// the specified function has prefix data attached.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+///
+/// # Returns
+///
+/// Returns `true` if the function has prefix data, or `false` otherwise.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+#[must_use]
+pub fn has_prefix_data(fn_val: &ValueRef) -> bool {
+    unsafe { core::LLVMHasPrefixData(fn_val.0) != 0 }
+}
+
+/// Sets the prefix data for the function.
+///
+/// This function wraps the `LLVMSetPrefixData` function from the LLVM core library. It attaches prefix data
+/// to the specified function.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `prefix_data`: The `ValueRef` representing the prefix data to attach.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The `prefix_data` must represent valid prefix data.
+pub fn set_prefix_data(fn_val: &ValueRef, prefix_data: &ValueRef) {
+    unsafe {
+        core::LLVMSetPrefixData(fn_val.0, prefix_data.0);
+    }
+}
+
+/// Retrieves the prologue data associated with a function.
+///
+/// This function wraps the `LLVMGetPrologueData` function from the LLVM core library. It obtains the prologue data
+/// attached to the specified function. Prologue data is used to attach additional information to functions.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+///
+/// # Returns
+///
+/// Returns an `Option<ValueRef>` containing the prologue data if it exists, or `None` otherwise.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The returned `ValueRef` should not be used if it is `None`.
+#[must_use]
+pub fn get_prologue_data(fn_val: &ValueRef) -> Option<ValueRef> {
+    unsafe {
+        let prologue_data = core::LLVMGetPrologueData(fn_val.0);
+        if prologue_data.is_null() {
+            None
+        } else {
+            Some(ValueRef(prologue_data))
+        }
+    }
+}
+
+/// Checks if a given function has prologue data.
+///
+/// This function wraps the `LLVMHasPrologueData` function from the LLVM core library. It determines whether
+/// the specified function has prologue data attached.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+///
+/// # Returns
+///
+/// Returns `true` if the function has prologue data, or `false` otherwise.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+#[must_use]
+pub fn has_prologue_data(fn_val: &ValueRef) -> bool {
+    unsafe { core::LLVMHasPrologueData(fn_val.0) != 0 }
+}
+
+/// Sets the prologue data for the function.
+///
+/// This function wraps the `LLVMSetPrologueData` function from the LLVM core library. It attaches prologue data
+/// to the specified function.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `prologue_data`: The `ValueRef` representing the prologue data to attach.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The `prologue_data` must represent valid prologue data.
+pub fn set_prologue_data(fn_val: &ValueRef, prologue_data: &ValueRef) {
+    unsafe {
+        core::LLVMSetPrologueData(fn_val.0, prologue_data.0);
+    }
+}
+
+/// Adds an attribute to a function at a specified index.
+///
+/// This function wraps the `LLVMAddAttributeAtIndex` function from the LLVM core library. Attributes provide
+/// additional metadata about functions, such as optimization hints or specific calling conventions.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `idx`: The `LLVMAttributeIndex` indicating where to add the attribute (e.g., function attributes, return attributes).
+/// - `attr`: The `LLVMAttributeRef` representing the attribute to add.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The `LLVMAttributeRef` must represent a valid attribute.
+pub fn add_attribute_at_index(fn_val: &ValueRef, idx: u32, attr: &AttributeRef) {
+    unsafe {
+        core::LLVMAddAttributeAtIndex(fn_val.0, *CUint::from(idx), attr.get_ref());
+    }
+}
+
+/// Retrieves the number of attributes at a specified index for a function.
+///
+/// This function wraps the `LLVMGetAttributeCountAtIndex` function from the LLVM core library. It returns the
+/// number of attributes present at the specified index.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `idx`: The `LLVMAttributeIndex` indicating which attribute set to query.
+///
+/// # Returns
+///
+/// Returns an `unsigned` integer representing the number of attributes at the specified index.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The `LLVMAttributeIndex` must be valid for the function.
+#[must_use]
+pub fn get_attribute_count_at_index(fn_val: &ValueRef, idx: u32) -> u32 {
+    unsafe { core::LLVMGetAttributeCountAtIndex(fn_val.0, *CUint::from(idx)) }
+}
+
+/// Retrieves all attributes at a specified index for a function.
+///
+/// This function wraps the `LLVMGetAttributesAtIndex` function from the LLVM core library. It fills the provided
+/// slice with the attributes present at the specified index.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `idx`: The `LLVMAttributeIndex` indicating which attribute set to query.
+/// - `attrs`: A mutable slice of `LLVMAttributeRef` where the attributes will be stored.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The `LLVMAttributeIndex` must be valid for the function.
+/// - The `attrs` slice must be large enough to hold all attributes at the specified index.
+pub fn get_attributes_at_index(fn_val: &ValueRef, idx: u32, attrs: &[AttributeRef]) {
+    let attrs_ptr = crate::to_mut_ptr!(attrs);
+    unsafe {
+        core::LLVMGetAttributesAtIndex(fn_val.0, *CUint::from(idx), attrs_ptr);
+    }
+}
+
+/// Retrieves an enum attribute at a specified index for a function.
+///
+/// This function wraps the `LLVMGetEnumAttributeAtIndex` function from the LLVM core library. It fetches the
+/// enum attribute corresponding to the provided `KindID` at the specified index.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `idx`: The `LLVMAttributeIndex` indicating where to retrieve the attribute.
+/// - `kind_id`: The `unsigned` integer representing the kind of enum attribute to retrieve.
+///
+/// # Returns
+///
+/// Returns an `Option<LLVMAttributeRef>` containing the attribute if found, or `None` otherwise.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The `KindID` must correspond to a valid enum attribute.
+#[must_use]
+pub fn get_enum_attribute_at_index(
+    fn_val: &ValueRef,
+    idx: u32,
+    kind_id: u32,
+) -> Option<AttributeRef> {
+    unsafe {
+        let attr =
+            core::LLVMGetEnumAttributeAtIndex(fn_val.0, *CUint::from(idx), *CUint::from(kind_id));
+        if attr.is_null() {
+            None
+        } else {
+            Some(AttributeRef::from(attr))
+        }
+    }
+}
+
+/// Retrieves a string attribute at a specified index for a function.
+///
+/// This function wraps the `LLVMGetStringAttributeAtIndex` function from the LLVM core library. It fetches the
+/// string attribute corresponding to the provided key at the specified index.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `idx`: The `LLVMAttributeIndex` indicating where to retrieve the attribute.
+/// - `key`: The key (`&str`) identifying the string attribute.
+///
+/// # Returns
+///
+/// Returns an `Option<LLVMAttributeRef>` containing the attribute if found, or `None` otherwise.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The `key` must not contain null bytes.
+#[must_use]
+pub fn get_string_attribute_at_index(
+    fn_val: &ValueRef,
+    idx: u32,
+    key: &str,
+) -> Option<AttributeRef> {
+    let c_key = CString::from(key);
+    unsafe {
+        let attr = core::LLVMGetStringAttributeAtIndex(
+            fn_val.0,
+            *CUint::from(idx),
+            c_key.as_ptr(),
+            *CUint::from(c_key.count_bytes()),
+        );
+        if attr.is_null() {
+            None
+        } else {
+            Some(AttributeRef::from(attr))
+        }
+    }
+}
+
+/// Removes an enum attribute at a specified index for a function.
+///
+/// This function wraps the `LLVMRemoveEnumAttributeAtIndex` function from the LLVM core library. It removes the
+/// enum attribute corresponding to the provided `KindID` at the specified index.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `idx`: The `LLVMAttributeIndex` indicating where to remove the attribute.
+/// - `kind_id`: The `unsigned` integer representing the kind of enum attribute to remove.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The `KindID` must correspond to a valid enum attribute.
+pub fn remove_enum_attribute_at_index(fn_val: &ValueRef, idx: u32, kind_id: u32) {
+    unsafe {
+        core::LLVMRemoveEnumAttributeAtIndex(fn_val.0, *CUint::from(idx), *CUint::from(kind_id));
+    }
+}
+
+/// Removes a string attribute at a specified index for a function.
+///
+/// This function wraps the `LLVMRemoveStringAttributeAtIndex` function from the LLVM core library. It removes the
+/// string attribute corresponding to the provided key at the specified index.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function.
+/// - `idx`: The `LLVMAttributeIndex` indicating where to remove the attribute.
+/// - `key`: The key (`&str`) identifying the string attribute to remove.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The `key` must not contain null bytes.
+pub fn remove_string_attribute_at_index(fn_val: &ValueRef, idx: u32, key: &str) {
+    let c_key = CString::from(key);
+    unsafe {
+        core::LLVMRemoveStringAttributeAtIndex(
+            fn_val.0,
+            *CUint::from(idx),
+            c_key.as_ptr(),
+            *CUint::from(c_key.count_bytes()),
+        );
+    }
+}
+
+/// Adds a target-dependent attribute to a function.
+///
+/// This function wraps the `LLVMAddTargetDependentFunctionAttr` function from the LLVM core library. It attaches
+/// a target-specific attribute with a specified value to the given function. Target-dependent attributes can be
+/// used to provide additional metadata or optimization hints that are specific to a particular target architecture.
+///
+/// # Parameters
+///
+/// - `fn_val`: The `ValueRef` representing the function to which the attribute will be added.
+/// - `attribute`: The name (`&str`) of the attribute to add.
+/// - `value`: The value (`&str`) associated with the attribute.
+///
+/// # Safety
+///
+/// - The `ValueRef` must represent a valid function within a module.
+/// - The `attribute` and `value` strings must not contain null bytes.
+///
+pub fn add_target_dependent_function_attr(fn_val: &ValueRef, attribute: &str, value: &str) {
+    let attr_cstr = CString::from(attribute);
+    let value_cstr = CString::from(value);
+    unsafe {
+        core::LLVMAddTargetDependentFunctionAttr(fn_val.0, attr_cstr.as_ptr(), value_cstr.as_ptr());
+    }
+}

--- a/src/core/values/mod.rs
+++ b/src/core/values/mod.rs
@@ -7,6 +7,7 @@ use llvm_sys::LLVMValueKind;
 use std::ops::Deref;
 
 pub mod constants;
+pub mod function_values;
 pub mod general;
 pub mod uses;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ pub mod basic_block;
 pub mod builder;
 pub mod core;
 
+#[macro_use]
+mod macros;
+
 use libc::{c_char, c_double, c_int, c_uint, size_t};
 use std::ops::{Deref, DerefMut};
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,26 @@
+/// Get a mutable pointer for the collection.
+#[macro_export]
+macro_rules! to_mut_ptr {
+    ($collection:expr) => {{
+        use $crate::GetRef;
+        let mut vec = $collection.iter().map(|v| v.get_ref()).collect::<Vec<_>>();
+        if vec.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            vec.as_mut_ptr()
+        }
+    }};
+}
+
+/// Get a mutable pointer for the collection with Map function.
+#[macro_export]
+macro_rules! map_mut_ptr {
+    ($collection:expr, $map_fn:expr) => {{
+        let mut vec = $collection.iter().map($map_fn).collect::<Vec<_>>();
+        if vec.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            vec.as_mut_ptr()
+        }
+    }};
+}


### PR DESCRIPTION
## Description

➡️ Added LLVM `Function Values`
➡️ Added LLVM `Function Values Parameters`
➡️ Refactored `mut ptr variables` to `macro` use - all over that whole code base.